### PR TITLE
Clarify install, config, and use for client SOP.

### DIFF
--- a/lib/clc_memo/report.Rnw
+++ b/lib/clc_memo/report.Rnw
@@ -126,7 +126,7 @@ Thank you for your efforts to increase the frequency of goals of care conversati
   rate_plot <- generate_rate_plot(plot_data,
     plot_title = "How many total newly admitted Veterans have a documented \ngoals of care conversation?",
     y_label = "Veterans Admitted",
-    line_label = "Newly admitted\nveterans",
+    line_label = "Newly admitted\nVeterans",
     stack_labels = c("Not documented", "Documented")
   )
   

--- a/lib/hbpc_memo/report.Rnw
+++ b/lib/hbpc_memo/report.Rnw
@@ -126,7 +126,7 @@ Thank you for your efforts to increase the frequency of goals of care conversati
   rate_plot <- generate_rate_plot(plot_data,
     plot_title = "How many total newly admitted Veterans have a documented \ngoals of care conversation?",
     y_label = "Veterans Admitted",
-    line_label = "Newly admitted\nveterans",
+    line_label = "Newly admitted\nVeterans",
     stack_labels = c("Not documented", "Documented")
   )
   # print plot to include in document

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,10 @@
 # Goals of Care Site Reports
 
+## Installation
+This project makes use of `Rscript`,`pandoc`, and `pdflatex`.
+All should be in the PATH of the executing user. 
+Ensure the R Packages listed in the prerequisites section are installed and available. 
+
 ## Prerequisites
 
 ### LaTeX
@@ -16,51 +21,66 @@ Home Page [https://cran.r-project.org/](https://cran.r-project.org/)
 Optionally, use RStudio to get a GUI. [https://www.rstudio.com/](https://www.rstudio.com/)
 
 ### R Packages
-* ggplot2
-* ggthemes
-* viridis
-* scales
-* tidyr
-* config
-* dplyr
-* knitr
+- ggplot2
+- ggthemes
+- viridis
+- scales
+- tidyverse
+- config
+- stringr
+- dplyr
+- knitr
+- rmarkdown
 
 Included under lib/ is an installer script that will attempt to download, build, and install required packages: [lib/required-packages.r](lib/required-packages.r)
 
 ## Use
 
 1. Gather input data and export in csv format with a header row into the input/ directory.
-    * Expected input file input/clc.csv
-    * Expected input file input/hbpc.csv
+    - Expected input file input/clc.csv
+    - Expected input file input/hbpc.csv
 
 1. Fill out the configuration file `config/report_settings.yml`
-    * An example config with defaults settings exits at `config/report_settings.yml.sample`
+    - An example config with defaults settings exists at `config/report_settings.yml.sample`
       ```console
       cp config/report_settings.yml.sample config/report_settings.yml
       ```
 
-1. From the project root directory, run the following commands in order:
-    ```console
-    # Run install script to make sure required packages are installed.
-    Rscript lib/install_required_packages.r
+1. Run the bash script to execute all commands, **OR** manually run each individually:
+    - **BASH Script** From project base directory, run the following:
+        ```console
+        # Run the commands to build the reports
+        bin/build_reports.sh
 
-    # Check that input data has expected headers
-    Rscript lib/check_input.r
+        # Check the log for errors
+        grep -e 'Error' build/build.log
+        ```
 
-    # Filter the input data
-    Rscript lib/filter_input.r
+    - **Manual** From the project base directory, run the following commands in order:
+        ```console
+        # Run install script to make sure required packages are installed.
+        Rscript lib/install_required_packages.r
 
-    # Calculate performance measure
-    Rscript lib/calc_perf_measures.r
+        # Check that input data has expected headers
+        Rscript lib/check_input.r
 
-    # Build all report figures and tex
-    Rscript lib/build_all_tex.r
+        # Filter the input data
+        Rscript lib/filter_input.r
 
-    # Compile all tex reports to pdf
-    find build -name '*.tex' -execdir pdflatex {} \;
+        # Calculate performance measure
+        Rscript lib/calc_perf_measures.r
 
-    # Generated pdf will be build/reports/<id>/<id>.clc.pdf
-    ```
+        # Build all report figures and tex
+        Rscript lib/build_all_tex.r
+
+        # Compile all tex reports to pdf
+        find build -name '*.tex' -execdir pdflatex {} \;
+
+        # Generated pdf will be build/reports/<id>_clc/<id>.clc.pdf
+        # Generated pdf will be build/reports/<id>_hbpc/<id>.hbpc.pdf
+        ```
+1. Collect the generated reports from the directory `build/reports/`
+
 ## Demo with synthetic data
 ```console
 # Generate fake data
@@ -72,13 +92,17 @@ bin/build_reports.sh
 
 ## Configuration
 Various strings that appear in the reports need to be changed per recipient.
-To facilitate this, those strings are specified in `config/report_settings.yml`.
+To facilitate this, those strings are specified in a yaml configuration file `config/report_settings.yml`.
+YAML overview: [https://en.wikipedia.org/wiki/YAML](https://en.wikipedia.org/wiki/YAML)
+YAML technical specification: [yaml.org](yaml.org)
 
 Important Config Notes
 - **The config file must exist**
 - The config must be filled out for each id that exists in the input data.
 - The config must start with the key `default`
 - The config should contain a config for `clc` & `hbpc`.
+
+Example:
 
 ```yaml
 ---
@@ -101,5 +125,3 @@ default:
         contacts: John Jones, Random Manager (555-222-1121)
         provider: Friendly Neighborhood Feedback Provider
 ```
-
-## License


### PR DESCRIPTION
Add links to yaml info for non-programmers
Add instructs for the build_all.sh convenience script.