### PR TITLE
Limit timescale and fill in missing time points.

### DIFF
--- a/lib/calc_perf_measures.r
+++ b/lib/calc_perf_measures.r
@@ -4,7 +4,6 @@
 #   misses
 #   numerator category sums
 
-  #results = calc_perf(clc_filename, clc_id_cols, clc_numer_cols, clc_denom_cols, clc_categories)
 calc_perf <- function(input_file, id_cols, numer_cols, denom_cols, numer_categories){
   # Assuming input rdata file has a flt_data data frame
   load(input_file)
@@ -45,7 +44,7 @@ clc_denom_cols <- c('goc_7', 'goc_14', 'goc_30', 'goc_pre90', 'goc_pre', 'goc_no
 
 # Performance measure config for HBPC
 hbpc_filename <- file.path("build","filtered_hbpc.rdata")
-hbpc_id_cols <- c("cdw_sta6a")
+hbpc_id_cols <- c("sta6a")
 hbpc_categories <- list("cat_1"=c("numer90","goc_pre"),
                         "cat_2"=c("numer1"),
                         "cat_3"=c("numer2"),

--- a/lib/filter_input.r
+++ b/lib/filter_input.r
@@ -1,8 +1,68 @@
 library(stringr)
+library(dplyr)
+
 # Read input data if it exists, filter, write to build directory
 read_in_data <- function(path, classes){
   df <- read.csv( path, header = TRUE, colClasses = classes )
   df 
+}
+
+# Given fy, quart, and number of quarts to go back, return df of fy quart to include
+# Parameters:
+#  fy: fiscal year of most recent timepoint
+#  quart: quarter of most recent timepoint
+#  num: number of quarters to go back
+# Return:
+#   dataframe with num length list of fy & quart starting with timepoint stepping back one quarter at a time
+# Description:
+#   Put everything in terms of sum of quarters 
+#   mapping q1 to 0 and q4 to 3 because 2000q4 != 2005
+#   e.g 2000Q1 => 8000, 2001Q4 => 8007 
+back_timepoints <- function(fy, quart, num){
+  qsum <- fy * 4 + (quart -1)
+  # Go back num quarters
+  qsum_min <- qsum - (num - 1)
+  # Make vector of qsum values 
+  qsum_vec <- seq(from=qsum_min, to=qsum)
+  
+  # Make vector of fy for each qsum value
+  fy_vec <- floor(qsum_vec/4)
+  # Make vector of quarter for each qsum value
+  quart_vec <- qsum_vec %% 4 + 1
+  
+  data.frame(fy=fy_vec,quart=quart_vec)
+}
+
+
+# Given a clc or hbpc data frame, return one with only the most recent x timepoints
+# Fill in rows for missing times
+filter_recent_times <- function(df, x){
+  # Find most recent time point
+  max_fy <- max(df$fy)
+  max_fy_filter <- df$fy == max_fy
+  max_quart <- max( df[max_fy_filter, c('quart')] )
+  
+  # get list of timepoints to include
+  times <- back_timepoints(max_fy, max_quart, x)
+  
+  # filter using included times
+  time_filter <- paste0(df$fy, df$quart) %in% paste0(times$fy, times$quart)
+  df_flt <- df[time_filter,]
+  
+  # Make list of all site & time point combinations that should be present
+  options(stringsAsFactors = FALSE)
+  site_times <- merge(unique(df$sta6a),times) %>% rename(sta6a=x)
+  
+  # Fill missing rows with NA for each ID by joining to the site_times table
+  df_flt <- df_flt %>% full_join(site_times)
+  
+  # Replace NAs with 0 for integer columns
+  int_cols <- sapply(df_flt, is.integer)
+  na_cells <- is.na(df_flt[, int_cols])
+  df_flt[,int_cols][na_cells] <- 0
+  
+  # return filtered dataframe
+  df_flt
 }
 
 # Filter the input data to get only the rows that will be used susequently
@@ -10,27 +70,16 @@ filter_clc_data <- function(df){
   # Covert column names to lower case
   names(df) <- str_to_lower(names(df))
   
-  # Create a array of boolean (TRUE) with one value per row in the data frame
-  filter <- rep(TRUE, nrow(df))
-  
-  # Only use rows with the treatment specialty value of "All Speciialties"
-  # Logical AND together the base filter with rows for which the condition is true
-  filter <- filter & df[,"trtsp_1"] == "All NH Treating Specialties"
-  
-  # Only use rows with a time in the top 8 time points (fiscal year quarters in practice)
-  # Unique Times, Top time index, top times dataframe
-  uniq_t <- unique(df[,c('fy','quart')])
-  top_t_idx <- order(uniq_t$fy, uniq_t$quart, decreasing=T)[1:8]
-  top_t <- uniq_t[top_t_idx, c('fy','quart')]
-  
-  # Add time_filter to overall filter
-  time_filter <- paste0(df$fy, df$quart) %in% paste0(top_t$fy, top_t$quart)
-  filter <- filter & time_filter
-  
-  # Apply filter to get filtered data
-  # Subset the data by selecting rows that correspond to TRUE in the filter.
+  # Filter for "All Specialties" summary rows
+  filter <- df[,"trtsp_1"] == "All NH Treating Specialties"
   flt_data <- df[filter,]
   
+  # Filter out all but most recent 8 times
+  flt_data <- filter_recent_times(flt_data, 8)
+  
+  
+  # Return filtered data
+  flt_data
 }
 
 # CLC input is input/clc.csv
@@ -52,7 +101,11 @@ if(file.exists(clc_filename)){
 
 if(file.exists(hbpc_filename)){
   hbpc_data <- read_in_data(hbpc_filename, hbpc_classes)
-  flt_data <- hbpc_data
+  
+  # Rename id column for consistency with clc then filter
+  flt_data <- hbpc_data %>%
+    rename(sta6a=cdw_sta6a) %>%
+    filter_recent_times(., 8)
   
   output_path = file.path("build","filtered_hbpc.rdata")
   save(flt_data, file = output_path)


### PR DESCRIPTION
A slightly more robust solution that what was done in #36 to address #30.
Still limit the report to the most recent 8 quarters observed, but fill in missing quarters with 0's as per direction from the stakeholder.

This PR includes the following:
- Fill in missing quarters. 
- Hard code to expect most recent 8 quarters.
- Change hbpc id column name (cdw_sta6a) to align with clc (sta6a)